### PR TITLE
Refactor/package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "@tanstack/react-router-devtools": "^1.131.32",
         "@tanstack/router-cli": "^1.131.35",
         "@tanstack/router-plugin": "^1.131.35",
-        "@tanstack/router-vite-plugin": "^1.131.36",
         "@types/node": "^24.3.0",
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import path from 'path'
 import { tanstackRouter } from '@tanstack/router-plugin/vite'
 
 export default defineConfig({
-  plugins: [react(), tanstackRouter({ target: 'react', autoCodeSplitting: true }), tailwindcss()],
+  plugins: [tanstackRouter({ target: 'react', autoCodeSplitting: true }), react(), tailwindcss()],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, 'src'),


### PR DESCRIPTION
@tanstack/router-vite-plugin 삭제
tanstackRouter()를 plugin 가장 앞으로 보내기

Delete @tanstack/router-vite-plugin 
Move tanstackRouter() to the very beginning of the plugins array.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted build plugin initialization order. No changes to configuration options.
  * No impact expected on existing features or user workflows.
  * Improves consistency of how the app is built and initialized across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->